### PR TITLE
CELDEV-1313 - add jakarta.mail to dependency management

### DIFF
--- a/base-pom/pom.xml
+++ b/base-pom/pom.xml
@@ -902,6 +902,11 @@
       </dependency>
       <!-- Mail sender -->
       <dependency>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>jakarta.mail</artifactId>
+        <version>2.0.2</version>
+      </dependency>
+      <dependency>
         <groupId>javax.mail</groupId>
         <artifactId>mail</artifactId>
         <version>1.4</version>


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1313

**Migrates mail dependencies from legacy `javax.mail` to Jakarta Mail.**
- Adds managed `com.sun.mail:jakarta.mail:2.0.2` in `base-pom`
- Replaces `javax.mail:mail` in `celements-xwiki-core`
- Updates mail imports in core and mailsender to `jakarta.mail` / `jakarta.activation`
- Ensures generated bytecode calls `MimeBodyPart.setDataHandler(jakarta.activation.DataHandler)`, fixing the production `NoSuchMethodError`
- Verified `celements-xwiki-core` and `celements-mailsender` compile, and `celements-webapp` no longer resolves `mail-1.4.jar`