### PR TITLE
fix asm includes & bump hibernate 3 final

### DIFF
--- a/celements-bom/pom.xml
+++ b/celements-bom/pom.xml
@@ -898,12 +898,7 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>3.3.2.GA</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-annotations</artifactId>
-        <version>3.4.0.GA</version>
+        <version>3.5.6-Final</version>
         <exclusions>
           <exclusion>
             <groupId>commons-collections</groupId>
@@ -913,26 +908,12 @@
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-commons-annotations</artifactId>
-        <version>3.3.0.ga</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-entitymanager</artifactId>
-        <version>3.4.0.GA</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate</artifactId>
-        <version>3.2.6.ga</version>
+        <artifactId>hibernate-annotations</artifactId>
+        <version>3.5.6-Final</version>
         <exclusions>
           <exclusion>
             <groupId>commons-collections</groupId>
@@ -969,7 +950,7 @@
         <artifactId>tika-parsers</artifactId>
         <version>1.28.5</version>
         <exclusions>
-          <!-- exclude asm, it is already included in hibernate -->
+          <!-- exclude asm, it is already included in cglib & hibernate -->
           <exclusion>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
@@ -1580,6 +1561,12 @@
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
         <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <!-- required by cglib & hibernate -->
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.10.1</version>
       </dependency>
       <dependency>
         <groupId>jmock</groupId>

--- a/celements-bom/pom.xml
+++ b/celements-bom/pom.xml
@@ -1262,11 +1262,6 @@
         <version>2.3.1</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.ws.rs</groupId>
-        <artifactId>jakarta.ws.rs-api</artifactId>
-        <version>3.1.0</version> <!-- 4.0.0 requires JDK 17, therefore fallback to 3.1.0 -->
-      </dependency>
-      <dependency>
         <!-- TODO [CELDEV-815] Upgrade to javax.servlet Spec 4.0 -->
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>

--- a/celements-parent/pom.xml
+++ b/celements-parent/pom.xml
@@ -16,7 +16,6 @@
     <release.version>${project.version}</release.version>
     <java.version>21</java.version>
     <nodejs.version>v24.11.1</nodejs.version>
-    <repo.url.celements>https://maven.celements.ch</repo.url.celements>
     <webapp.surefire.integration.skip>true</webapp.surefire.integration.skip>
   </properties>
   <dependencyManagement>
@@ -300,33 +299,11 @@
       </snapshots>
     </repository>
     <repository>
-      <id>celements-externals</id>
-      <name>Celements Maven2 Remote Repository for Third Party Dependencies</name>
-      <url>${repo.url.celements}/externals</url>
+      <id>celements-forge</id>
+      <name>Celements Maven Repository</name>
+      <url>${repo.url.celements}</url>
       <releases>
         <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>celements-releases</id>
-      <name>Celements Maven2 Remote Repository for Releases</name>
-      <url>${repo.url.celements}/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>celements-snapshots</id>
-      <name>Celements Maven2 Remote Repository for Snapshots</name>
-      <url>${repo.url.celements}/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,12 @@
   </organization>
   <distributionManagement>
     <snapshotRepository>
-      <id>celements-snapshot-repository</id>
-      <url>${repo.url.dist.celements}/snapshots</url>
-      <uniqueVersion>true</uniqueVersion>
+      <id>celements-forge</id>
+      <url>${repo.url.dist.celements}</url>
     </snapshotRepository>
     <repository>
-      <id>celements-release-repository</id>
-      <url>${repo.url.dist.celements}/releases</url>
-      <uniqueVersion>true</uniqueVersion>
+      <id>celements-forge</id>
+      <url>${repo.url.dist.celements}</url>
     </repository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
1. fixes occasional startup failures by including jdk21 compatible asm version `9.10.1`
2. removes deprecated org.hibernate:hibernate artifact
3. bumps hibernate-core to lates v3 final `3.5.6-Final`

celements & updateschema works just fine now

```
$ ls WEB-INF/lib/hibernate-*
WEB-INF/lib/hibernate-annotations-3.5.6-Final.jar
WEB-INF/lib/hibernate-core-3.5.6-Final.jar
WEB-INF/lib/hibernate-commons-annotations-3.2.0.Final.jar
WEB-INF/lib/hibernate-jpa-2.0-api-1.0.0.Final.jar

$ ls WEB-INF/lib/cglib-*
WEB-INF/lib/cglib-3.3.0.jar

$ ls WEB-INF/lib/asm-*
WEB-INF/lib/asm-9.10.1.jar
```

also solves https://synjira.atlassian.net/browse/CELDEV-1325 "Replace UriBuilder jakarta JAX-RS with Spring variant"