### PR TITLE
CELDEV-1334 Manage navigation REST artifact

### DIFF
--- a/celements-bom/pom.xml
+++ b/celements-bom/pom.xml
@@ -195,6 +195,11 @@
       </dependency>
       <dependency>
         <groupId>com.celements</groupId>
+        <artifactId>celements-navigation-rest</artifactId>
+        <version>${release.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.celements</groupId>
         <artifactId>celements-observation</artifactId>
         <version>${release.version}</version>
       </dependency>


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1334
## Summary

- add `com.celements:celements-navigation-rest` to `celements-bom` dependency management
- use the coordinated `${release.version}` like the other Celements artifacts

## Coordinated delivery

Draft 3 of 4 for CELDEV-1334:

1. celements/celements-spring#31
2. celements/celements-base#309
3. celements/celements-parent-poms#142
4. celements/celements-web#556

Merge and publication order must preserve these dependencies before deploying the webapp.

## Validation

- `celements-bom` validation passed
- coordinated webapp dependency convergence and WAR packaging passed
- manually tested and approved by the requester