### PR TITLE
spotless-maven-plugin

### DIFF
--- a/celements-parent/pom.xml
+++ b/celements-parent/pom.xml
@@ -221,9 +221,29 @@
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>3.9.0</version>
+          <configuration>
+            <java>
+              <eclipse>
+                <file>https://raw.githubusercontent.com/celements/synventis-tools/refs/heads/dev/eclipse/synventis-code-formatter.xml</file>
+              </eclipse>
+              <importOrder>
+                <file>https://raw.githubusercontent.com/celements/synventis-tools/refs/heads/dev/eclipse/synventis.importorder</file>
+              </importOrder>
+              <removeUnusedImports />
+            </java>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
spotless plugin for manual executions:
```bash
mvn spotless:apply
mvn spotless:check
```
`spotless:check` execution not bound to `verify` goal.